### PR TITLE
fix build with gcc15 / c23

### DIFF
--- a/include/unit_test_util.h
+++ b/include/unit_test_util.h
@@ -29,6 +29,7 @@
 #ifndef UNITTESTS_H
 #define UNITTESTS_H
 
+#include <stbool.h>
 #include <stdio.h>
 #include <stdlib.h>
 #include <string.h>
@@ -39,23 +40,6 @@
 #ifdef __cplusplus
 extern "C" {
 #endif
-
-#ifdef bool
-#undef bool
-#endif
-
-#ifdef true
-#undef true
-#endif
-
-#ifdef false
-#undef false
-#endif
-
-    typedef int bool;
-#define true 1
-#define false 0
-
 
     int number_of_assertions;
 


### PR DESCRIPTION
fix:
```c
gcc -g -Wall -Wwrite-strings -funroll-loops -Wstrict-prototypes -I. -Iinclude -fPIC -Ofast -DSVD_ACTIVATED=1 -DCTRLC=1  -DCOPYAMATRIX=1  -DLAPACK_LIB_FOUND -DUSE_LAPACK -c src/unit_test_util.c -o out/obj/unit_test_util.o
In file included from src/unit_test_util.c:36:
include/unit_test_util.h:55:17: error: 'bool' cannot be defined via 'typedef'
   55 |     typedef int bool;
      |                 ^~~~
include/unit_test_util.h:55:17: note: 'bool' is a keyword with '-std=c23' onwards
include/unit_test_util.h:55:5: warning: useless type name in empty declaration
   55 |     typedef int bool;
      |     ^~~~~~~
```